### PR TITLE
Fix config + move the pip command to the prep notebook

### DIFF
--- a/0_setup.ipynb
+++ b/0_setup.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ab54974",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if the conda install failed in the previous step of the quickstart please uncomment and run the following code to install the neccessary pacakges using pip\n",
+    "# !pip install snowflake-snowpark-python pandas notebook scikit-learn cachetools pyarrow==10.0.1"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ca55fc73-9400-4e8d-9981-9483f4b51ec4",
    "metadata": {},
@@ -22,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0d83105c-5f25-4fd5-aa43-f6c118171af9",
    "metadata": {},
@@ -39,9 +52,8 @@
    "outputs": [],
    "source": [
     "connection_parameters = {\n",
-    "    \"account\": \"\",\n",
+    "    \"account\": \"\", # e.g. xy12345.us-east-2.aws\n",
     "    \"user\": \"\", \n",
-    "    \"host\": \"\", # e.g. \"sn00111.snowflakecomputing.com\",\n",
     "    \"password\": \"\",\n",
     "    \"role\": \"ACCOUNTADMIN\",\n",
     "    \"database\": \"HOL_DB\",\n",
@@ -52,6 +64,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "43b2c05f-6399-470e-bb36-ce0aefb8815f",
    "metadata": {},

--- a/0_setup.ipynb
+++ b/0_setup.ipynb
@@ -12,7 +12,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ca55fc73-9400-4e8d-9981-9483f4b51ec4",
    "metadata": {},
@@ -34,7 +33,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0d83105c-5f25-4fd5-aa43-f6c118171af9",
    "metadata": {},
@@ -64,7 +62,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "43b2c05f-6399-470e-bb36-ce0aefb8815f",
    "metadata": {},

--- a/1_prepare_build_deploy_model.ipynb
+++ b/1_prepare_build_deploy_model.ipynb
@@ -43,7 +43,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nteract": {
@@ -201,7 +200,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nteract": {
@@ -324,7 +322,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nteract": {
@@ -375,7 +372,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nteract": {

--- a/1_prepare_build_deploy_model.ipynb
+++ b/1_prepare_build_deploy_model.ipynb
@@ -3,16 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# if the conda install failed in the previous step of the quickstart please uncomment and run the following code to install the neccessary pacakges using pip\n",
-    "# pip install snowflake-snowpark-python pandas notebook scikit-learn cachetools pyarrow==10.0.1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "gather": {
@@ -53,6 +43,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nteract": {
@@ -210,6 +201,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nteract": {
@@ -332,6 +324,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nteract": {
@@ -382,6 +375,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nteract": {


### PR DESCRIPTION
the connection parameters in the 0_prepare notebook uses the host property, which is useless since we rely on the account property
the pip instruction to install all the libraries is placed in the 0_prepare notebook